### PR TITLE
Corrected rsync example's caption

### DIFF
--- a/src/5.0/en/source.xml
+++ b/src/5.0/en/source.xml
@@ -927,7 +927,7 @@
     </table>
 
     <example id="source.rsync.example.xml">
-      <title>redis XML example</title>
+      <title>rsync XML example</title>
       <programlisting><![CDATA[<!-- source rsync -->
 <source type="rsync">
   <option name="path" value="/tmp/foo"/>
@@ -935,7 +935,7 @@
     </example>
 
     <example id="source.rsync.example.json">
-      <title>redis JSON example</title>
+      <title>rsync JSON example</title>
       <programlisting><![CDATA[{
   "type": "rsync",
   "options": {


### PR DESCRIPTION
Previously read "redis XML example" and "redis JSON example" for rsync examples