### PR TITLE
CLI: Added missing options to listing

### DIFF
--- a/src/5.2/en/cli.xml
+++ b/src/5.2/en/cli.xml
@@ -35,19 +35,22 @@ OK (1 backup, 0 checks, 0 encryption, 0 syncs, 0 cleanups)</screen>
     </para>
 
     <screen>$ <userinput>phpbu --help</userinput>
-<![CDATA[phpbu 5.2.0 by Sebastian Feldmann and Contributors.
+<![CDATA[phpbu 5.2.10 by Sebastian Feldmann and contributors.
 
 Usage: phpbu [option]
 
---bootstrap=<file>     A "bootstrap" PHP file that is included before the backup.
---configuration=<file> A phpbu xml config file.
---colors               Use colors in output.
---debug                Display debugging information during backup generation.
---limit=<subset>       Limit backup execution to a subset.
---simulate             Perform a trial run with no changes made.
--h, --help             Print this usage information.
--v, --verbose          Output more verbose information.
--V, --version          Output version information and exit.]]></screen>
+--bootstrap=<file>       A "bootstrap" PHP file that is included before the backup.
+--configuration=<file>   A phpbu configuration file.
+--colors                 Use colors in output.
+--debug                  Display debugging information during backup generation.
+--generate-configuration Create a new configuration skeleton.
+--limit=<subset>         Limit backup execution to a subset.
+--simulate               Perform a trial run with no changes made.
+-h, --help               Print this usage information.
+-v, --verbose            Output more verbose information.
+-V, --version            Output version information and exit.
+--version-check          Check whether phpbu is up to date.
+--self-update            Upgrade phpbu to the latest version.]]></screen>
 
     <variablelist>
 

--- a/src/6.0/en/cli.xml
+++ b/src/6.0/en/cli.xml
@@ -39,15 +39,18 @@ OK (1 backup, 0 checks, 0 encryption, 0 syncs, 0 cleanups)</screen>
 
 Usage: phpbu [option]
 
---bootstrap=<file>     A "bootstrap" PHP file that is included before the backup.
---configuration=<file> A phpbu xml config file.
---colors               Use colors in output.
---debug                Display debugging information during backup generation.
---limit=<subset>       Limit backup execution to a subset.
---simulate             Perform a trial run with no changes made.
--h, --help             Print this usage information.
--v, --verbose          Output more verbose information.
--V, --version          Output version information and exit.]]></screen>
+--bootstrap=<file>       A "bootstrap" PHP file that is included before the backup.
+--configuration=<file>   A phpbu configuration file.
+--colors                 Use colors in output.
+--debug                  Display debugging information during backup generation.
+--generate-configuration Create a new configuration skeleton.
+--limit=<subset>         Limit backup execution to a subset.
+--simulate               Perform a trial run with no changes made.
+-h, --help               Print this usage information.
+-v, --verbose            Output more verbose information.
+-V, --version            Output version information and exit.
+--version-check          Check whether phpbu is up to date.
+--self-update            Upgrade phpbu to the latest version.]]></screen>
 
     <variablelist>
 


### PR DESCRIPTION
I updated the listing to the current output.

I did not add explanations (`varlistentry` items) because IMHO the info in the listing is sufficient.