### PR TITLE
Logging Table Heading Wrong

### DIFF
--- a/src/6.0/en/logging.xml
+++ b/src/6.0/en/logging.xml
@@ -37,7 +37,7 @@
     </para>
 
     <table id="logging.tables.options.email">
-      <title>Capacity-Options</title>
+      <title>Email-Options</title>
       <tgroup cols="5" align="left" colsep="1" rowsep="1">
         <thead>
           <row>


### PR DESCRIPTION
This fixes a presumably copy-paste error in the heading of the Email logger options table