### PR TITLE
Typo In MySQL Source Options

### DIFF
--- a/src/6.0/en/source.xml
+++ b/src/6.0/en/source.xml
@@ -629,7 +629,7 @@
             <entry>true | false</entry>
             <entry>no</entry>
             <entry>false</entry>
-            <entry>Use the --hex-blob option to dump blog fields in hex.</entry>
+            <entry>Use the --hex-blob option to dump blob fields in hex.</entry>
           </row>
           <row>
             <entry>lockTables</entry>


### PR DESCRIPTION
This fixes a typo in mysql hexBlob option description