### PR TITLE
JSON Primitive Integers

### DIFF
--- a/src/6.0/en/check.xml
+++ b/src/6.0/en/check.xml
@@ -74,7 +74,7 @@
       <title>SizeDiffPreviousPercent JSON example</title>
 
       <programlisting><![CDATA[
-{"type": "SizeDiffPreviousPercent", "value": "10"}]]></programlisting>
+{"type": "SizeDiffPreviousPercent", "value": 10}]]></programlisting>
 
     </example>
 

--- a/src/6.0/en/cleanup.xml
+++ b/src/6.0/en/cleanup.xml
@@ -219,7 +219,7 @@
       <programlisting><![CDATA[{
   "type": "quantity",
   "options": {
-    "amount": "20"
+    "amount": 20
   }
 }]]></programlisting>
     </example>
@@ -315,11 +315,11 @@ backups | ............| . . . . . . . . . | .       .       .     | .           
       <programlisting><![CDATA[{
   "type": "stepwise",
   "options": {
-    "daysToKeepAll": "2",
-    "daysToKeepDaily": "5",
-    "weeksToKeepWeekly": "3",
-    "monthToKeepMonthly": "4",
-    "yearsToKeepYearly": "10"
+    "daysToKeepAll": 2,
+    "daysToKeepDaily": 5,
+    "weeksToKeepWeekly": 3,
+    "monthToKeepMonthly": 4,
+    "yearsToKeepYearly": 10
   }
 }]]></programlisting>
     </example>
@@ -361,7 +361,7 @@ backups | ............| . . . . . . . . . | .       .       .     | .           
     "token": "mysecrettoken",
     "path": "/backups",
     "cleanup.type": "quantity",
-    "cleanup.amount": "10"
+    "cleanup.amount": 10
   }
 }]]></programlisting>
     </example>


### PR DESCRIPTION
Updates JSON examples to use primitive integers rather than strings which contain numbers