### PR TITLE
Webhook JSON Example

### DIFF
--- a/src/6.0/en/logging.xml
+++ b/src/6.0/en/logging.xml
@@ -327,8 +327,7 @@
       <programlisting><![CDATA[{
   "type": "webhook",
   "options": {
-     "transport": "uri",
-     "recipients": "http://example.com/hook"
+     "uri": "http://example.com/hook"
    }
 }]]></programlisting>
     </example>


### PR DESCRIPTION
The JSON example for webhooks is incorrect, this PR fixes that